### PR TITLE
fix(slugrunner): for ruby 2.6.0 with new MJIT

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18
+FROM heroku/heroku:18-build
 
 RUN mkdir /app
 RUN addgroup --quiet --gid 2000 slug && \


### PR DESCRIPTION
this ensures that compilers are available at runtime in hephy/slugrunner:v2.6.0