### PR TITLE
chore(slugrunner): rebuild slugrunner, objstorage

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ EXPOSE 5000
 
 ADD ./runner /runner
 ADD ./bin /bin
-ADD https://storage.googleapis.com/object-storage-cli/bb8e054/objstorage-bb8e054-linux-amd64 /bin/objstorage
+ADD https://storage.googleapis.com/object-storage-cli/bb209cb/objstorage-bb209cb-linux-amd64 /bin/objstorage
 RUN chmod +x /bin/objstorage && \
     chown slug:slug /app \
                     /runner/init \


### PR DESCRIPTION
It looks like in Workflow v2.20.0 the slugrunner got a new image tag but didn't actually get a new build, in order to rebuild slugrunner, we have to reclaim the storage bucket https://storage.googleapis.com/object-storage-cli that at-arschles (?) was running, but is no longer.

I did that, and I published a new version of object-storage-cli there, so our slugrunner builds can proceed normally again.

There is a new commit hash for object-storage-cli [bb209cb](https://github.com/teamhephy/object-storage-cli/commit/bb209cb17e0d8fcce2c58d565732d432b33bb66c) and this probably trickles down to resolve a number of issues I'll have to track down and notify later, in slugrunner or in other components that use the object-storage-cli.

I will make the rounds today and see if I can find and update every component using object-storage-cli for v2.20.1 next!