### PR TITLE
chore(slugrunner): peg objstorage to the last known good version

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ EXPOSE 5000
 
 ADD ./runner /runner
 ADD ./bin /bin
-ADD https://storage.googleapis.com/object-storage-cli/bb209cb/objstorage-bb209cb-linux-amd64 /bin/objstorage
+ADD https://storage.googleapis.com/hephy-obj-storage-cli/bb8e054/objstorage /bin/objstorage
 RUN chmod +x /bin/objstorage && \
     chown slug:slug /app \
                     /runner/init \


### PR DESCRIPTION
Signed-off-by: Cryptophobia <aouzounov@gmail.com>

We have to do this until we rebuild https://github.com/teamhephy/object-storage-cli and test that everything works. Changes in https://github.com/teamhephy/distribution/pull/2 could have broken it.